### PR TITLE
게시글 수정이 안되는 현상

### DIFF
--- a/src/main/java/com/springboard/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/springboard/projectboard/controller/ArticleController.java
@@ -2,7 +2,6 @@ package com.springboard.projectboard.controller;
 
 import com.springboard.projectboard.domain.constant.FormStatus;
 import com.springboard.projectboard.domain.constant.SearchType;
-import com.springboard.projectboard.dto.UserAccountDto;
 import com.springboard.projectboard.dto.request.ArticleRequest;
 import com.springboard.projectboard.dto.response.ArticleResponse;
 import com.springboard.projectboard.dto.response.ArticleWithCommentsResponse;

--- a/src/main/java/com/springboard/projectboard/service/ArticleService.java
+++ b/src/main/java/com/springboard/projectboard/service/ArticleService.java
@@ -63,7 +63,9 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+            UserAccount userAccount = userAccountRepository
+                    .findById(dto.userAccountDto().userId())
+                    .orElseThrow(() -> new EntityNotFoundException("사용자 계정을 찾을 수 없습니다."));
 
             if (article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) { article.setTitle(dto.title()); }


### PR DESCRIPTION
fix: 게시글 수정 시 사용자 비교 실패 문제 해결

게시글 작성자와 로그인 사용자의 ID는 같았으나,
프록시 객체(getReferenceById)와 실제 객체 간 equals 비교에서 실패 발생.
findById()로 실제 엔티티를 로딩하도록 변경하여 문제 해결.

추가로 사용하지 않은 import 정리

This closes #57 